### PR TITLE
Add Delete Round Functionality

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code owners for SpeedScore repository
 
 # JavaScript files
-*.js  @VedantChaskar/js-team
+*.js  @VedantChaskar/jsteam
 
 # HTML files
-*.html @VedantChaskar/html-team
+*.html @VedantChaskar/htmlteam

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code owners for SpeedScore repository
 
 # JavaScript files
-*.js  @VedantChaskar/jsteam
+*.js  @cs561-sp25/jsteam
 
 # HTML files
-*.html @VedantChaskar/htmlteam
+*.html @cs561-sp25/htmlteam

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for SpeedScore repository
+
+# JavaScript files
+*.js  @VedantChaskar/js-team
+
+# HTML files
+*.html @VedantChaskar/html-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code owners for SpeedScore repository
 
 # JavaScript files
-*.js  @cs561-sp25/jsteam
+*.js  @VedantChaskar
 
 # HTML files
-*.html @cs561-sp25/htmlteam
+*.html @VedantChaskar

--- a/index.html
+++ b/index.html
@@ -1557,6 +1557,41 @@
                     </div>
                 </form>
             </div>
+            <div class="modal" tabindex="-1" id="confirmDeleteRoundModal">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Delete Round?</h5>
+                            <button
+                                type="button"
+                                class="btn-close"
+                                data-bs-dismiss="modal"
+                                aria-label="Close"
+                            ></button>
+                        </div>
+                        <div class="modal-body">
+                            <p>Do you really want to delete that round?</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button
+                                type="button"
+                                class="btn btn-secondary"
+                                data-bs-dismiss="modal"
+                            >
+                                No, Cancel
+                            </button>
+                            <button
+                                type="button"
+                                id="confirmDeleteBtn"
+                                class="btn btn-primary"
+                                onClick=""
+                            >
+                                Yes, Delete Round
+                            </button>
+                        </div>
+                    </div>
+                </div>
+              </div>
         </main>
         <script
             src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -218,6 +218,45 @@ writeRoundToTable(thisRound,rowIndex);
 }
 
 /*************************************************************************
+ * @function confirmDelete
+ * @desc
+ * Present pop-up modal dialog asking user to confirm delete operation
+ * @param roundId -- the unique id of the round to be deleted
+ * @returns -- true if user confirms delete, false otherwise
+ *************************************************************************/
+function confirmDelete(roundId) {
+  //TO DO: Present modal dialog prompting user to confirm delete
+  //Return true if user confirms delete, false otherwise
+  let modal = new bootstrap.Modal(
+      document.getElementById("confirmDeleteRoundModal")
+  );
+  let confirmBtn = document.getElementById("confirmDeleteBtn");
+  confirmBtn.addEventListener("click", function (event) {
+      event.preventDefault();
+      console.log("deleting round with id " + roundId);
+      for (var i = 0; i < GlobalRoundsTable.rows.length; i++) {
+          let row = GlobalRoundsTable.rows[i];
+          // Check if the id of the row matches the id you're looking for
+          if (row.id === "r-" + roundId) {
+              GlobalRoundsTable.deleteRow(i);
+              break;
+          }
+      }
+      deleteRound(roundId);
+      localStorage.setItem(
+          GlobalUserData.accountInfo.email,
+          JSON.stringify(GlobalUserData)
+      );
+      GlobalRoundsTableCaption.textContent =
+          "Table displaying " +
+          (GlobalRoundsTable.rows.length - 1) +
+          " speedgolf rounds";
+      modal.hide();
+  });
+  modal.show();
+}
+
+/*************************************************************************
 * @function populateRoundsTable 
 * @desc 
 * Iterate through the userData.rounds array, adding a row corresponding

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -217,6 +217,20 @@ const thisRound = document.getElementById("r-" + GlobalUserData.rounds[rowIndex]
 writeRoundToTable(thisRound,rowIndex);
 }
 
+
+/*************************************************************************
+ * @function deleteRound
+ * @desc
+ * Deletes a round from the "Rounds" table and from local storage
+ * @param roundId -- the unique id of the round to be deleted
+ * @returns -- true if round could be deleted, false otherwise
+ *************************************************************************/
+function deleteRound(roundId) {
+  GlobalUserData.rounds = GlobalUserData.rounds.filter(function (round) {
+      return round.roundNum !== roundId;
+  });
+}
+
 /*************************************************************************
  * @function confirmDelete
  * @desc

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -184,6 +184,8 @@ GlobalUserData.rounds[rIndex].seconds +
 "onclick='confirmDelete(" + GlobalUserData.rounds[rIndex].roundNum + ")'>" +
 "<span class='fas fa-trash'></span></button></td>";
 }
+/* 
+Delete round*/
 
 /*************************************************************************
 * @function addRoundToTable 

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -16,6 +16,8 @@
  function updateSGS() {
   GlobalRoundSGS.value = 
     (GlobalRoundStrokes.valueAsNumber + GlobalRoundMinutes.valueAsNumber) + 
+
+   
     ":" + GlobalRoundSeconds.value
 }
 
@@ -33,6 +35,7 @@ function changeSeconds() {
   if (GlobalRoundSeconds.value.length < 2) {
     GlobalRoundSeconds.value = "0" + GlobalRoundSeconds.value;
   }
+ 
   updateSGS();
 }
 


### PR DESCRIPTION
# Delete Round Functionality

## Issue Link
Resolves #1

## Description
This pull request implements the functionality for users to delete rounds from the Rounds table. 
The implementation includes:

1. A confirmation modal dialog that appears when a user clicks the delete button
2. Logic to confirm deletion with the user before removing the round
3. Functionality to remove the round from both the displayed table and localStorage

## Implementation Details

### HTML Changes
- Added a Bootstrap modal dialog to index.html that prompts users to confirm deletion
- Included "No, Cancel" and "Yes, Delete Round" buttons as specified
- Ensured the modal is properly styled and accessible

### JavaScript Changes
- Added `confirmDelete()` function that displays the modal and handles user interaction
- Added `deleteRound()` function that removes the round data from GlobalUserData and updates localStorage
- Connected the deletion functionality to the existing rounds table

## How This Meets Acceptance Criteria

- [x] When the user clicks on the garbage can icon in a round row, the "Confirm Round Deletion" dialog box appears through the `confirmDelete()` function
- [x] The dialog box asks the user: "Do you really want to delete that round?" as specified
- [x] The dialog box has two choice buttons: "No, Cancel" (the default), and "Yes, Delete Round"
- [x] Clicking on "No, Cancel" dismisses the dialog without performing further action
- [x] Clicking on "Yes, Delete Round" dismisses the dialog and deletes the round from both the table and localStorage

## Testing
Manually tested the feature by:
- Creating sample rounds
- Clicking the delete button
- Confirming and canceling deletion
- Verifying rounds are properly removed from the table and localStorage